### PR TITLE
176 adding team to league

### DIFF
--- a/admin/get_add_league_team.php
+++ b/admin/get_add_league_team.php
@@ -14,6 +14,7 @@ $ez_league = new ezAdmin_League();
 if(isset($_POST['id'])) {
 	$league_id = $_POST['id'];
 	 $league = $ez_league->get_league( $league_id );
+	 $max_teams = $league['teams'];
 	 $available_teams = $ez_league->get_available_teams( $league_id );
 	 $current_teams   = $ez_league->get_league_teams( $league_id );
 	 $current_teams_count = count( $current_teams );
@@ -67,7 +68,7 @@ if(isset($_POST['id'])) {
               <div style="height: auto;" id="collapseOne" class="panel-collapse">
                 <div class="panel-body">
               		<div class="table-responsive">
-	                    <table class="table table-hover league-teams">
+	                    <table class="table table-hover league-teams" data-max-teams="<?php echo $max_teams; ?>">
 	                        <thead>
 	                            <tr>
 	                            	<th>Team</th>

--- a/admin/header.php
+++ b/admin/header.php
@@ -1,5 +1,5 @@
 <?php session_start();
-define( 'EZL_VERSION', '3.5.7' );
+define( 'EZL_VERSION', '3.5.8' );
 $check_for_update = file_get_contents( 'http://www.mdloring.com/ezleague_version.php', TRUE );
 include('lib/class-db.php');
 include('lib/class-ezadmin.php');

--- a/admin/js/ezleague/league.js
+++ b/admin/js/ezleague/league.js
@@ -283,7 +283,7 @@ $('#editRules').submit(function(e) {
  */
  function addLeagueTeam(league_id, team_id) {
 	
-	var max_teams   = $('.league-teams-heading').data('max-teams');
+	var max_teams   = $('.league-teams').data('max-teams');
 		total_teams = $('.current-teams-amount').data('total-teams');
 
 	$.ajax({

--- a/admin/lib/objects/class-league.php
+++ b/admin/lib/objects/class-league.php
@@ -531,7 +531,7 @@ class ezAdmin_League extends DB_Class {
 
 	public function get_available_teams($league_id) {
 		
-		$data = $this->fetch("SELECT id, guild FROM `" . $this->prefix . "guilds` WHERE leagues NOT LIKE '%$league_id%'");
+		$data = $this->fetch("SELECT id, guild FROM `" . $this->prefix . "guilds` WHERE (leagues IS NULL) OR (leagues NOT LIKE '%$league_id%')");
 		return $data;
 		
 	}

--- a/header.php
+++ b/header.php
@@ -1,5 +1,5 @@
 <?php session_start();
-define( 'EZL_VERSION', '3.5.7' );
+define( 'EZL_VERSION', '3.5.8' );
 include('lib/class-db.php');
 include('lib/class-ezleague.php');
 


### PR DESCRIPTION
- pass the maximum team amount for a league to the "Add Team" popup (when on the View League admin page)
- check if an individual team's `leagues` column is NULL to ensure they show up in the "Available Teams" list
- bump versioning to 3.5.8

addresses a bug submitted by @calibershock for https://github.com/stoopkid1/ezleague/issues/176